### PR TITLE
Add ArgoCD wave number to plan CRD object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow to override the SUC pod affinity
 - Rename parameter backoff_limit to job_backoff_limit
 - Change parameters.cluster.dist to parameters.facts.distribution ([#7])
+- Add ArgoCD wave number to plan CRD object
 
 [Unreleased]: https://github.com/projectsyn/component-system-upgrade-controller/compare/2606b0b...HEAD
 

--- a/lib/suc.libjsonnet
+++ b/lib/suc.libjsonnet
@@ -7,6 +7,9 @@ local params = inv.parameters.system_upgrade_controller;
   Plan(name, channel, label_selectors, concurrency, tolerations, image, push_gateway, command): kube._Object('upgrade.cattle.io/v1', 'Plan', name) {
     metadata+: {
       namespace: params.namespace,
+      annotations+: {
+        'argocd.argoproj.io/sync-wave': '5',
+      },
       labels+: {
         'app.kubernetes.io/managed-by': 'syn',
       },


### PR DESCRIPTION
ArgoCD must deploy the plan CRD after set up all SUC components.
This ensures the object kind plan.upgrade.cattle.io/v1
is known to the cluster.

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the ./CHANGELOG.md.
