### PR TITLE
Allow ArgoCD to skip dry run for SUC Plan resources if CRD is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 ### Added
 - Index and reference documentation
 - Add support to define tolerations in SUC pods
@@ -14,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add ArgoCD wave number to plan CRD object
 - Update the SUC image from v0.5 to docker.io/rancher/system-upgrade-controller:v0.6.2
 
+### Fixed
+- Allow ArgoCD to skip dry run for plan resources if CRD is missing ([#14])
+
 [Unreleased]: https://github.com/projectsyn/component-system-upgrade-controller/compare/2606b0b...HEAD
 
 [#7]: https://github.com/projectsyn/component-system-upgrade-controller/pull/7
+[#14]: https://github.com/projectsyn/component-system-upgrade-controller/pull/14

--- a/lib/suc.libjsonnet
+++ b/lib/suc.libjsonnet
@@ -8,7 +8,7 @@ local params = inv.parameters.system_upgrade_controller;
     metadata+: {
       namespace: params.namespace,
       annotations+: {
-        'argocd.argoproj.io/sync-wave': '5',
+        'argocd.argoproj.io/sync-options': 'SkipDryRunOnMissingResource=true',
       },
       labels+: {
         'app.kubernetes.io/managed-by': 'syn',


### PR DESCRIPTION
The annotation `argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true` allows ArgoCD to ignore errors due to the Plan CRD missing on the first apply. The dry run is still performed when the CRD exists.

Fixes #11

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the ./CHANGELOG.md.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
