### PR TITLE
More robust var handling & allow version to be set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add ArgoCD wave number to plan CRD object
 - Update the SUC image from v0.5 to docker.io/rancher/system-upgrade-controller:v0.6.2
 - Support for arbitrary argument pass-through for plans ([#16])
+- Support for version variable in a plan
+- Support for the command variable to be a string or array
+- Allow to not set push_gateway variable
 
 ### Fixed
 - Allow ArgoCD to skip dry run for plan resources if CRD is missing ([#14])

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -176,21 +176,20 @@ local plan = [
         error 'Field `args` of plan "%(name)s" is not an array' % p
     ) else
       [];
-    
-  local command(p) = 
+
+  local command(p) =
     if std.objectHas(p, 'command') then (
       if std.type(p.command) == 'string' then (
-        [ p.command ] 
+        [ p.command ]
       )
       else (
         if std.type(p.command) == 'array' then (
           p.command
         ) else
           error 'Field `command` of plan "%(name)s" is not an array nor a string' % p
-      ) 
+      )
     ) else
       [];
-    
 
   local version = (
     if std.objectHas(p, 'version') then

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -171,11 +171,18 @@ local plan = [
   local args(p) =
     if std.objectHas(p, 'args') then (
       if std.type(p.args) == 'array' then
-        p.args
+        if std.objectHas(p, 'push_gateway') then
+          std.prune(p.args + [ p.push_gateway ])
+        else
+          p.args
       else
         error 'Field `args` of plan "%(name)s" is not an array' % p
-    ) else
-      [];
+    ) else (
+      if std.objectHas(p, 'push_gateway') then
+        [ p.push_gateway ]
+      else
+        null
+    );
 
   local command(p) =
     if std.objectHas(p, 'command') then (
@@ -189,11 +196,9 @@ local plan = [
           error 'Field `command` of plan "%(name)s" is not an array nor a string' % p
       )
     ) else
-      [];
+      null;
 
   local version = if std.objectHas(p, 'version') then p.version;
-
-  local push_gateway = if std.objectHas(p, 'push_gateway') then p.push_gateway;
 
   suc.Plan(p.name,
            channel,
@@ -202,7 +207,6 @@ local plan = [
            p.concurrency,
            p.tolerations,
            p.image,
-           push_gateway,
            command(p),
            args(p))
   for p in params.plans

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -191,12 +191,7 @@ local plan = [
     ) else
       [];
 
-  local version = (
-    if std.objectHas(p, 'version') then
-      p.version
-    else
-      ''
-  );
+  local version = if std.objectHas(p, 'version') then p.version;
 
   local push_gateway = if std.objectHas(p, 'push_gateway') then p.push_gateway;
 

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -198,12 +198,7 @@ local plan = [
       ''
   );
 
-  local push_gateway = (
-    if std.objectHas(p, 'push_gateway') then
-      p.push_gateway
-    else
-      ''
-  );
+  local push_gateway = if std.objectHas(p, 'push_gateway') then p.push_gateway;
 
   suc.Plan(p.name,
            channel,

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -176,15 +176,45 @@ local plan = [
         error 'Field `args` of plan "%(name)s" is not an array' % p
     ) else
       [];
+    
+  local command(p) = 
+    if std.objectHas(p, 'command') then (
+      if std.type(p.command) == 'string' then (
+        [ p.command ] 
+      )
+      else (
+        if std.type(p.command) == 'array' then (
+          p.command
+        ) else
+          error 'Field `command` of plan "%(name)s" is not an array nor a string' % p
+      ) 
+    ) else
+      [];
+    
+
+  local version = (
+    if std.objectHas(p, 'version') then
+      p.version
+    else
+      ''
+  );
+
+  local push_gateway = (
+    if std.objectHas(p, 'push_gateway') then
+      p.push_gateway
+    else
+      ''
+  );
 
   suc.Plan(p.name,
            channel,
+           version,
            p.label_selectors,
            p.concurrency,
            p.tolerations,
            p.image,
-           p.push_gateway,
-           p.command,
+           push_gateway,
+           command(p),
            args(p))
   for p in params.plans
 ];

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -158,6 +158,9 @@ Currently, this behavior can't be changed.
 This parameter is optional.
 If provided, this plan parameter overrides the Floodgate channel constructed from plan parameters `hour` and `day` in combination with component parameter `floodgate_url`.
 
+`version`: The Image Version.
+Providing a value for `version` will prevent polling/resolution of the `channel` if specified.
+
 `hour`: A Floodgate point in time 0..24 (hour).
 This parameter can be omitted if plan parameter `channel` is provided.
 

--- a/lib/suc.libjsonnet
+++ b/lib/suc.libjsonnet
@@ -3,7 +3,7 @@ local kube = import 'lib/kube.libjsonnet';
 local inv = kap.inventory();
 local params = inv.parameters.system_upgrade_controller;
 {
-  Plan(name, channel, label_selectors, concurrency, tolerations, image, push_gateway, command, args):
+  Plan(name, channel, version, label_selectors, concurrency, tolerations, image, push_gateway, command, args):
     kube._Object('upgrade.cattle.io/v1', 'Plan', name) {
       metadata+: {
         namespace: params.namespace,
@@ -25,9 +25,10 @@ local params = inv.parameters.system_upgrade_controller;
           force: true,
         },
         channel: channel,
+        version: version,
         upgrade: {
           image: image,
-          command: [ command ],
+          command: command,
           args: std.prune(args + [ push_gateway ]),
         },
       },

--- a/lib/suc.libjsonnet
+++ b/lib/suc.libjsonnet
@@ -3,7 +3,8 @@ local kube = import 'lib/kube.libjsonnet';
 local inv = kap.inventory();
 local params = inv.parameters.system_upgrade_controller;
 {
-  Plan(name, channel, version, label_selectors, concurrency, tolerations, image, push_gateway, command, args):
+  Plan(name, channel, version, label_selectors, concurrency, tolerations, image, command, args):
+
     kube._Object('upgrade.cattle.io/v1', 'Plan', name) {
       metadata+: {
         namespace: params.namespace,
@@ -24,12 +25,12 @@ local params = inv.parameters.system_upgrade_controller;
         drain: {
           force: true,
         },
-        channel: channel,
-        version: version,
+        [if channel != null then 'channel']: channel,
+        [if version != null then 'version']: version,
         upgrade: {
           image: image,
-          command: command,
-          args: std.prune(args + [ push_gateway ]),
+          [if command != null then 'command']: command,
+          [if args != null then 'args']: args,
         },
       },
     },


### PR DESCRIPTION
* Allow to set the `version` variable in a plan
* Allow to pass a `command` array or a string (to stay compatible and have the same behaviour) in a plan. The plan requires an array.
* Allow to not set the `push_gateway` variable in a plan

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update the ./CHANGELOG.md.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
