### PR TITLE
Add support for arbitrary configurations in `Plan` resources

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -14,6 +14,5 @@ parameters:
     service_account: system-upgrade
     plan_polling_interval: "15m"
     suc_image: docker.io/rancher/system-upgrade-controller:v0.6.2
-    floodgate_url: https://floodgate.syn.vshn.net/
+    floodgate_url: https://floodgate.syn.vshn.net
     disable_grafana_dashboard: false
-    plans: []

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -227,7 +227,7 @@ local plans = [
     },
   }
 
-  for pname in std.objectFields(planConfigs)
+  for pname in std.sort(std.objectFields(planConfigs))
   if planConfigs[pname] != null
 ];
 

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -177,7 +177,7 @@ local convertLegacyPlan(p) = std.trace(
     },
     tolerations: {
       [t.key]: t
-      for t in p.tolerations
+      for t in com.getValueOrDefault(p, 'tolerations', [])
     },
     floodgate: {
       day: p.day,
@@ -209,7 +209,9 @@ local plans = [
     else
       error 'Field `spec.upgrade.command` of plan "%s" is not an array nor a string' % pname;
 
-  suc.Plan(pname, p.label_selectors, p.tolerations) {
+  local tolerations = com.getValueOrDefault(p, 'tolerations', {});
+
+  suc.Plan(pname, p.label_selectors, tolerations) {
     spec+: com.makeMergeable(p.spec) + {
       channel:
         if 'channel' in super then

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -6,7 +6,7 @@ See the xref:references/parameters.adoc[parameters] reference for further detail
 
 == Example for Ubuntu 20.04 (Focal)
 
-A minimal example to maintain all nodes of a cluster running Kubernetes 1.18 and Ubuntu 20.04 starting Tuesday at 22:00 having a node label `plan.upgrade.cattle.io/focal`:
+A minimal example to maintain all nodes with label `plan.upgrade.cattle.io/focal` of a cluster running Kubernetes 1.18 and Ubuntu 20.04 starting Tuesday at 22:00:
 
 ```
 parameters:
@@ -14,19 +14,23 @@ parameters:
     job_kubectl_image: rancher/kubectl:v1.18.0
     disable_grafana_dashboard: true
     plans:
-      - name: system-upgrade
-        concurrency: 1
-        image: docker.io/projectsyn/suc-ubuntu-focal
-        command: /scripts/run.sh
-        # push_gateway: platform-prometheus-pushgateway.syn-synsights.svc:9091
-        push_gateway: 10.43.129.22:9091
-        day: 2  # Tuesday
-        hour: 22
+      focal:
+        spec:
+          concurrency: 1
+          upgrade:
+            image: docker.io/projectsyn/suc-ubuntu-focal
+            command: /scripts/run.sh
+          # push_gateway: platform-prometheus-pushgateway.syn-synsights.svc:9091
+          push_gateway: 10.43.129.22:9091
+        floodgate:
+          day: 2  # Tuesday
+          hour: 22
         label_selectors:
-          - {key: plan.upgrade.cattle.io/focal, operator: Exists}
-        tolerations:
-          - key: node-role.kubernetes.io/controlplane
+          plan.upgrade.cattle.io/focal:
             operator: Exists
-          - key: node-role.kubernetes.io/etcd
+        tolerations:
+          node-role.kubernetes.io/controlplane:
+            operator: Exists
+          node-role.kubernetes.io/etcd:
             operator: Exists
 ```

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -156,71 +156,185 @@ The time in seconds the System Upgrade Controller jobs are kept after they're co
 == `plans`
 
 [horizontal]
-type:: list
-default:: `[]`
+type:: dict
+default:: `{}`
 
-Defines the parameters for an System Upgrade Controller plan.
+This parameter allows users to configure one or more System Upgrade Controller `Plan` resources.
 
-`name`: Name of the selected channel.
+Each entry in the dict corresponds to one `Plan` resource.
+Dict keys are used as the name of the resulting `Plan` resource.
+The dict value is expected to be another dict.
+The component supports keys `spec`, `floodgate`, `label_selectors` and `tolerations` in the value dict.
 
-`concurrency`: The amount of jobs can run simultaneously.
+Plans can be removed by setting the value of the dict entry to `null`.
 
-`image`: Syn includes the https://github.com/projectsyn/system-upgrade-controller-package-upgrade[System Upgrade Controller OS Package Upgrade Script] which is available as container image on docker hub for https://hub.docker.com/r/projectsyn/suc-ubuntu-bionic[Ubuntu 18.04 (bionic)] and https://hub.docker.com/r/projectsyn/suc-ubuntu-focal/[Ubuntu 20.04 (focal)].
+=== `plans.<P>.spec`
 
-`command`: This parameter specifies the command for the job pods.
-In the case of the System Upgrade Controller OS Package Upgrade Script this is `/scripts/run.sh`.
+[horizontal]
+type:: dict
+default::
++
+[source,yaml]
+----
+nodeSelector:
+  matchExpressions:
+    <from plans.<P>.label_selectors>
+serviceAccountName: <params.service_account>
+tolerations:
+  <from plans.<P>.tolerations>
+drain:
+  force: true
+----
 
-`push_gateway`: A Prometheus push gateway address as DNS name or IP.
-The value of this parameter is appended to any arbitrary arguments given in `args`.
-Currently, this behavior can't be changed.
+This parameter is mandatory.
+A minimal configuration requires fields `upgrade.image` and `upgrade.command` to be set.
 
-`channel`: A System Upgrade Controller compliant channel.
+This parameter is merged with  the predefined configuration shown above to form the `Plan` resource's `spec` field.
+Configurations in the parameter override values in the default.
+Configurations given in other fields in the plan configuration may override values provided in this parameter.
+See the following sections for details.
+
+The component accepts both string and array values for `spec.upgrade.command`.
+If a string value is given, it's transformed into an array with a single member.
+
+See the https://github.com/rancher/system-upgrade-controller#example-plans[System Upgrade Controller documentation] for supported configurations.
+
+=== `plans.<P>.floodgate`
+
+[horizontal]
+type:: dict
+supported keys:: `url`, `basepath`, `day`, `hour`
+
+This parameter is required unless field `channel` is present in plan parameter `spec`.
+This parameter can be used to instruct the component to construct a Floodgate-based value for the plan's channel.
+If field `channel` in key `plans.<P>.spec` is set, configuration provided in this parameter has no effect.
+
+The supported keys in this parameter have the following effects:
+
+`url`:: The base URL of the Floodgate instance.
+This key is optional.
+If it's not present, the value of component parameter `floodgate_url` is used in the resulting channel value.
+
+`basepath`:: The base path appended to the Floodgate URL.
+This key is optional.
+If it's not present, the component uses `window` as base path.
+
+`day`:: The day of the week on which to start the upgrade.
+This should be a number between 0 (Sunday) and 6 (Saturday).
+
+`hour`:: The hour in the day on which to start the upgrade
+This should be a number between 0 and 23.
+
+See the https://github.com/projectsyn/floodgate/blob/master/docs/modules/ROOT/pages/index.adoc[Floodgate documentation] for details on how Floodgate works.
+
+=== `plans.<P>.push_gateway`
+
+[horizontal]
+type:: string
+
+A Prometheus push gateway address as DNS name or IP.
 This parameter is optional.
-If provided, this plan parameter overrides the Floodgate channel constructed from plan parameters `hour` and `day` in combination with component parameter `floodgate_url`.
+If present, the value of this parameter is appended to any arbitrary arguments given in the plan's `spec.upgrade.args`.
+If you need more complex configuration, please provide any arguments to the upgrade command directly in `spec.upgrade.args` and omit this parameter
 
-`version`: The Image Version.
-Providing a value for `version` will prevent polling/resolution of the `channel` if specified.
+=== `plans.<P>.label_selectors`
 
-`hour`: A Floodgate point in time 0..24 (hour).
-This parameter can be omitted if plan parameter `channel` is provided.
+[horizontal]
+type:: dict
 
-`day`: A Floodgate point in time 0=Sunday, 6=Saturday.
-This parameter can be omitted if plan parameter `channel` is provided.
+Specify a label selector according to which nodes to upgrade are selected.
+This parameter is mandatory.
+The System Upgrade Controller will add and manage label `plan.upgrade.cattle.io/P` for a plan named `P` to all nodes selected by the label selectors.
+It will set the value of that label to the SHA256 hash of the Docker image used for the upgrade.
+It's considered best practice to use that label as the label selector for the plan.
 
-`label_selectors`: A node label to specify a node is patched using a specified channel.
+The component will transform the provided dict into a list of Kubernetes label selector `matchExpressions`.
+Each dict entry is transformed into a `LabelSelectorRequirement`.
+The value of each entry used as the `LabelSelectorRequirement` and the key of the entry is set as the value for field `key`.
 
-`tolerations`: Tolerations for the job pods.
-In example to run the jobs also on control plane nodes a taint is configured for etcd or control plane components.
+The resulting list of `LabelSelectorRequirements` is assigned to key `spec.nodeSelector.matchExpressions` in the  `Plan` resource.
 
-`args`: Arbitrary arguments for the job command.
-This field is optional, but must be of type `array` when specified.
+See the https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/label-selector/#LabelSelector[Kubernetes API documentation] for supported fields in `LabelSelectorRequirement`.
 
-Example:
-```
+=== `plans.<P>.tolerations`
+
+[horizontal]
+type:: dict
+
+Specify Kubernetes tolerations for the upgrade job.
+This parameter is optional.
+If omitted, no tolerations are configured on the plan.
+
+The component transforms the provided dict into a list of Kubernetes tolerations.
+Each dict entry is transformed into a `Toleration` by the component.
+The entry's value is used as a `Toleration` and the entry's key is set as value for field `key`.
+
+The component assigns the resulting list of tolerations to field `spec.tolerations` in the `Plan`.
+
+See the https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling[Kubernetes API documentation] for supported fields in `Toleration`.
+
+
+=== Example Plan
+
+In this example, we specify a taint for etcd or control plane components so that the upgrade jobs can be scheduled on nodes hosting control plane or etcd components.
+
+[source,yaml]
+----
 parameters:
   system_upgrade_controller:
     plans:
-      - name: system-upgrade-1
-        concurrency: 1
-        image: docker.io/projectsyn/suc-ubuntu-focal
-        command: /scripts/run.sh
-        args:
-          - some_argument
+      focal: <1>
+        spec: <2>
+          concurrency: 1
+          upgrade:
+            image: docker.io/projectsyn/suc-ubuntu-focal
+            command: /scripts/run.sh
+            args:
+              - some_argument
+          channel: http://192.168.5.42:8091/
         push_gateway: 10.43.209.108:9091
-        channel: http://192.168.5.42:8091/
-        hour: 22 # is not applied if channel is set
-        day: 3 # is not applied if channel is set
+        floodgate:
+          hour: 22 # is not applied if channel is set
+          day: 3 # is not applied if channel is set
         label_selectors:
-          - {key: plan.upgrade.cattle.io/focal, operator: Exists}
+          plan.upgrade.cattle.io/focal: <1>
+            operator: Exists
         tolerations:
-          - key: node-role.kubernetes.io/controlplane
+          node-role.kubernetes.io/controlplane:
             operator: Exists
-          - key: node-role.kubernetes.io/etcd
+          node-role.kubernetes.io/etcd:
             operator: Exists
-      - name: system-upgrade-2
-        channel: something_else
-        label_selectors:
-          - tbd2
-```
+----
+<1> We recommend to use matching label selector and plan name.
+This minimizes the amount of labels added to nodes by the System Upgrade Controller.
+<2> Check the https://github.com/rancher/system-upgrade-controller#example-plans[official documentation] for supported fields in `spec`.
 
-Check the https://github.com/rancher/system-upgrade-controller#example-plans[official documentation] for more background details.
+
+This configuration results in the following `Plan` object:
+
+[source,yaml]
+----
+apiVersion: upgrade.cattle.io/v1
+kind: Plan
+metadata:
+  name: system-upgrade-focal
+spec:
+  channel: https://floodgate.syn.vshn.net/window/2/7
+  concurrency: 1
+  drain:
+    force: true
+  nodeSelector:
+    matchExpressions:
+      - key: plan.upgrade.cattle.io/system-upgrade-focal
+        operator: Exists
+  serviceAccountName: system-upgrade
+  tolerations:
+    - key: node-role.kubernetes.io/master
+      operator: Exists
+  upgrade:
+    args:
+      - platform-prometheus-pushgateway.syn-synsights.svc.cluster.local:9091
+    command:
+      - /scripts/run.sh
+    image: docker.io/projectsyn/suc-ubuntu-focal
+----

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -205,9 +205,9 @@ See the https://github.com/rancher/system-upgrade-controller#example-plans[Syste
 type:: dict
 supported keys:: `url`, `basepath`, `day`, `hour`
 
-This parameter is required unless field `channel` is present in plan parameter `spec`.
+This parameter is required unless either field `channel` or field `version` is present in plan parameter `spec`.
 This parameter can be used to instruct the component to construct a Floodgate-based value for the plan's channel.
-If field `channel` in key `plans.<P>.spec` is set, configuration provided in this parameter has no effect.
+If field `channel` or field `version` in key `plans.<P>.spec` is set, configuration provided in this parameter has no effect.
 
 The supported keys in this parameter have the following effects:
 

--- a/lib/suc.libjsonnet
+++ b/lib/suc.libjsonnet
@@ -3,7 +3,7 @@ local kube = import 'lib/kube.libjsonnet';
 local inv = kap.inventory();
 local params = inv.parameters.system_upgrade_controller;
 {
-  Plan(name, channel, version, label_selectors, concurrency, tolerations, image, command, args):
+  Plan(name, label_selectors, tolerations):
 
     kube._Object('upgrade.cattle.io/v1', 'Plan', name) {
       metadata+: {
@@ -16,7 +16,6 @@ local params = inv.parameters.system_upgrade_controller;
         },
       },
       spec: {
-        concurrency: concurrency,
         nodeSelector: {
           matchExpressions: label_selectors,
         },
@@ -24,13 +23,6 @@ local params = inv.parameters.system_upgrade_controller;
         tolerations: tolerations,
         drain: {
           force: true,
-        },
-        [if channel != null then 'channel']: channel,
-        [if version != null then 'version']: version,
-        upgrade: {
-          image: image,
-          [if command != null then 'command']: command,
-          [if args != null then 'args']: args,
         },
       },
     },

--- a/lib/suc.libjsonnet
+++ b/lib/suc.libjsonnet
@@ -1,29 +1,54 @@
+local com = import 'lib/commodore.libjsonnet';
 local kap = import 'lib/kapitan.libjsonnet';
 local kube = import 'lib/kube.libjsonnet';
 local inv = kap.inventory();
 local params = inv.parameters.system_upgrade_controller;
-{
-  Plan(name, label_selectors, tolerations):
 
-    kube._Object('upgrade.cattle.io/v1', 'Plan', name) {
-      metadata+: {
-        namespace: params.namespace,
-        annotations+: {
-          'argocd.argoproj.io/sync-options': 'SkipDryRunOnMissingResource=true',
-        },
-        labels+: {
-          'app.kubernetes.io/managed-by': 'syn',
-        },
+
+local floodgate_channel(fgspec) =
+  local url = com.getValueOrDefault(fgspec, 'url', params.floodgate_url);
+  local basepath = com.getValueOrDefault(fgspec, 'basepath', 'window');
+  '%(url)s/%(basepath)s/%(day)s/%(hour)s' % fgspec {
+    url: url,
+    basepath: basepath,
+  };
+
+local plan(name, labelSelectorDict, tolerationDict) =
+  local label_selectors = [
+    labelSelectorDict[l] { key: l }
+    for l in std.objectFields(labelSelectorDict)
+    if labelSelectorDict[l] != null
+  ];
+  local tolerations = [
+    tolerationDict[t] { key: t }
+    for t in std.objectFields(tolerationDict)
+    if tolerationDict[t] != null
+  ];
+
+
+  kube._Object('upgrade.cattle.io/v1', 'Plan', name) {
+    metadata+: {
+      namespace: params.namespace,
+      annotations+: {
+        'argocd.argoproj.io/sync-options': 'SkipDryRunOnMissingResource=true',
       },
-      spec: {
-        nodeSelector: {
-          matchExpressions: label_selectors,
-        },
-        serviceAccountName: params.service_account,
-        tolerations: tolerations,
-        drain: {
-          force: true,
-        },
+      labels+: {
+        'app.kubernetes.io/managed-by': 'syn',
       },
     },
+    spec: {
+      nodeSelector: {
+        matchExpressions: label_selectors,
+      },
+      serviceAccountName: params.service_account,
+      tolerations: tolerations,
+      drain: {
+        force: true,
+      },
+    },
+  };
+
+{
+  Plan: plan,
+  floodgate_channel: floodgate_channel,
 }

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -6,28 +6,36 @@ parameters:
     plan_day: 2
     plan_hour: 7
     plan_tolerations:
-      - key: node-role.kubernetes.io/master
+      node-role.kubernetes.io/master:
         operator: Exists
 
     plans:
-      - name: system-upgrade-focal
-        concurrency: 1
-        image: docker.io/projectsyn/suc-ubuntu-focal
-        command: /scripts/run.sh
+      system-upgrade-focal:
+        spec:
+          concurrency: 1
+          upgrade:
+            image: docker.io/projectsyn/suc-ubuntu-focal
+            command: /scripts/run.sh
         push_gateway: platform-prometheus-pushgateway.${synsights:namespace}.svc.cluster.local:9091
-        day: ${system_upgrade_controller:plan_day}
-        hour: ${system_upgrade_controller:plan_hour}
+        floodgate:
+          day: ${system_upgrade_controller:plan_day}
+          hour: ${system_upgrade_controller:plan_hour}
         label_selectors:
-          - {key: plan.upgrade.cattle.io/focal, operator: Exists}
+          plan.upgrade.cattle.io/system-upgrade-focal:
+            operator: Exists
         tolerations: ${system_upgrade_controller:plan_tolerations}
 
-      - name: system-upgrade-bionic
-        concurrency: 1
-        image: docker.io/projectsyn/suc-ubuntu-bionic
-        command: /scripts/run.sh
+      system-upgrade-bionic:
+        spec:
+          concurrency: 1
+          upgrade:
+            image: docker.io/projectsyn/suc-ubuntu-bionic
+            command: /scripts/run.sh
         push_gateway: platform-prometheus-pushgateway.${synsights:namespace}.svc.cluster.local:9091
-        day: ${system_upgrade_controller:plan_day}
-        hour: ${system_upgrade_controller:plan_hour}
+        floodgate:
+          day: ${system_upgrade_controller:plan_day}
+          hour: ${system_upgrade_controller:plan_hour}
         label_selectors:
-          - {key: plan.upgrade.cattle.io/bionic, operator: Exists}
+          plan.upgrade.cattle.io/system-upgrade-bionic:
+            operator: Exists
         tolerations: ${system_upgrade_controller:plan_tolerations}

--- a/tests/golden/defaults/system-upgrade-controller/system-upgrade-controller/05_plans.yaml
+++ b/tests/golden/defaults/system-upgrade-controller/system-upgrade-controller/05_plans.yaml
@@ -5,36 +5,6 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     app.kubernetes.io/managed-by: syn
-    name: system-upgrade-focal
-  name: system-upgrade-focal
-  namespace: syn-system-upgrade-controller
-spec:
-  channel: https://floodgate.syn.vshn.net/window/2/7
-  concurrency: 1
-  drain:
-    force: true
-  nodeSelector:
-    matchExpressions:
-      - key: plan.upgrade.cattle.io/focal
-        operator: Exists
-  serviceAccountName: system-upgrade
-  tolerations:
-    - key: node-role.kubernetes.io/master
-      operator: Exists
-  upgrade:
-    args:
-      - platform-prometheus-pushgateway.syn-synsights.svc.cluster.local:9091
-    command:
-      - /scripts/run.sh
-    image: docker.io/projectsyn/suc-ubuntu-focal
----
-apiVersion: upgrade.cattle.io/v1
-kind: Plan
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-  labels:
-    app.kubernetes.io/managed-by: syn
     name: system-upgrade-bionic
   name: system-upgrade-bionic
   namespace: syn-system-upgrade-controller
@@ -45,7 +15,7 @@ spec:
     force: true
   nodeSelector:
     matchExpressions:
-      - key: plan.upgrade.cattle.io/bionic
+      - key: plan.upgrade.cattle.io/system-upgrade-bionic
         operator: Exists
   serviceAccountName: system-upgrade
   tolerations:
@@ -57,3 +27,33 @@ spec:
     command:
       - /scripts/run.sh
     image: docker.io/projectsyn/suc-ubuntu-bionic
+---
+apiVersion: upgrade.cattle.io/v1
+kind: Plan
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  labels:
+    app.kubernetes.io/managed-by: syn
+    name: system-upgrade-focal
+  name: system-upgrade-focal
+  namespace: syn-system-upgrade-controller
+spec:
+  channel: https://floodgate.syn.vshn.net/window/2/7
+  concurrency: 1
+  drain:
+    force: true
+  nodeSelector:
+    matchExpressions:
+      - key: plan.upgrade.cattle.io/system-upgrade-focal
+        operator: Exists
+  serviceAccountName: system-upgrade
+  tolerations:
+    - key: node-role.kubernetes.io/master
+      operator: Exists
+  upgrade:
+    args:
+      - platform-prometheus-pushgateway.syn-synsights.svc.cluster.local:9091
+    command:
+      - /scripts/run.sh
+    image: docker.io/projectsyn/suc-ubuntu-focal


### PR DESCRIPTION
Refactor Plan management to better match the Project Syn component guidelines (see https://syn.tools/syn/explanations/jsonnet.html#_merging_external_config_data)

The PR retains backwards-compatibility with legacy plan specifications, but will print a notice when it converts legacy plan configurations into the new format.

The new format allows users to configure arbitrary field in the `Plan` resource's spec via parameter `spec` of the new plan configuration. Detailed documentation of the new format is available in the component docs.

Fixes #36 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
