### PR TITLE
Add alerting for halted maintenance

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -8,7 +8,7 @@ parameters:
     plans_only: false
     controller_threads: "2"
     affinity: {}
-    debug_logging: 'false'
+    debug_logging: "false"
     job_backoff_limit: "3"
     job_deadline_seconds: "900"
     job_image_pull_policy: "Always"
@@ -20,3 +20,6 @@ parameters:
     plan_polling_interval: "15m"
     floodgate_url: https://floodgate.syn.vshn.net
     disable_grafana_dashboard: false
+    monitoring:
+      enabled: true
+      prometheusRuleNamespace: syn-synsights

--- a/class/system-upgrade-controller.yml
+++ b/class/system-upgrade-controller.yml
@@ -9,3 +9,7 @@ parameters:
           - system-upgrade-controller/component/main.jsonnet
         input_type: jsonnet
         output_path: system-upgrade-controller/
+      - input_paths:
+          - system-upgrade-controller/component/alertrules.jsonnet
+        input_type: jsonnet
+        output_path: system-upgrade-controller/

--- a/component/alertrules.jsonnet
+++ b/component/alertrules.jsonnet
@@ -1,0 +1,47 @@
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+local inv = kap.inventory();
+local params = inv.parameters.system_upgrade_controller;
+
+local alert_rules =
+  kube._Object('monitoring.coreos.com/v1', 'PrometheusRule', 'system-upgrade-controller-alert-rules') {
+    metadata+: {
+      namespace: params.monitoring.prometheusRuleNamespace,
+      labels+: {
+        role: 'alert-rules',
+        prometheus: 'platform',
+      },
+    },
+    spec: {
+      groups: [
+        {
+          name: 'system-upgrade-controller.rules',
+          rules: [
+            {
+              alert: 'SYN_SystemUpgradeControllerMaintenanceHalted',
+              expr: 'kube_node_spec_unschedulable >= 1',
+              'for': '15m',
+              labels: {
+                severity: 'warning',
+                syn: 'true',
+                syn_component: 'system-upgrade-controller',
+              },
+              annotations: {
+                message: 'Maintenance halted',
+                description: 'system-upgrade-controller has stopped because the node {{ $labels.node }} cannot be drained. Check job logs for more information.',
+                runbook_url: 'https://hub.syn.tools/systen-upgrade-controller/runbooks/SystemUpgradeControllerMaintenanceHalted.html',
+                severity_level: 'warning',
+              },
+            },
+          ],
+        },
+      ],
+    },
+  };
+
+if params.monitoring.enabled then
+  {
+    '10_prometheusrule_system_upgrade_controller-alerts': alert_rules,
+  }
+else
+  {}

--- a/component/alertrules.jsonnet
+++ b/component/alertrules.jsonnet
@@ -29,7 +29,7 @@ local alert_rules =
               annotations: {
                 message: 'Maintenance halted',
                 description: 'system-upgrade-controller has stopped because the node {{ $labels.node }} cannot be drained. Check job logs for more information.',
-                runbook_url: 'https://hub.syn.tools/systen-upgrade-controller/runbooks/SystemUpgradeControllerMaintenanceHalted.html',
+                runbook_url: 'https://hub.syn.tools/system-upgrade-controller/runbooks/SystemUpgradeControllerMaintenanceHalted.html',
                 severity_level: 'warning',
               },
             },

--- a/docs/modules/ROOT/pages/runbooks/SystemUpgradeControllerMaintenanceHalted.adoc
+++ b/docs/modules/ROOT/pages/runbooks/SystemUpgradeControllerMaintenanceHalted.adoc
@@ -1,0 +1,26 @@
+= Alert rule: SystemUpgradeControllerMaintenanceHalted
+
+include::partial$runbooks/contribution_note.adoc[]
+
+== icon:glasses[] Overview
+
+This alert fires when a node remains unschedulable for 15 minutes.
+This is mostly caused because the node cannot be drained.
+To resolve this alert, check the logs for the system-upgrade-controller job on the node.
+
+
+== icon:bug[] Steps for debugging
+
+Get the Pod name for the job on the node:
+
+[source,console]
+----
+kubectl get pods -n cattle-system
+----
+
+Check the logs for the system-upgrade-controller job on the node:
+
+[source,console]
+----
+kubectl logs -n cattle-system -c drain <pod-name>
+----

--- a/docs/modules/ROOT/pages/runbooks/SystemUpgradeControllerMaintenanceHalted.adoc
+++ b/docs/modules/ROOT/pages/runbooks/SystemUpgradeControllerMaintenanceHalted.adoc
@@ -5,7 +5,7 @@ include::partial$runbooks/contribution_note.adoc[]
 == icon:glasses[] Overview
 
 This alert fires when a node remains unschedulable for 15 minutes.
-This is mostly caused because the node cannot be drained.
+This is mostly caused because the node can't be drained.
 To resolve this alert, check the logs for the system-upgrade-controller job on the node.
 
 

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -1,2 +1,6 @@
 * xref:index.adoc[Home]
 * xref:references/parameters.adoc[Parameters]
+
+.Alert runbooks
+
+* xref:runbooks/SystemUpgradeControllerMaintenanceHalted.adoc[SystemUpgradeControllerMaintenanceHalted]

--- a/docs/modules/ROOT/partials/runbooks/contribution_note.adoc
+++ b/docs/modules/ROOT/partials/runbooks/contribution_note.adoc
@@ -1,0 +1,5 @@
+[NOTE]
+====
+Please consider opening a PR to improve this runbook if you gain new information about causes of the alert, or how to debug or resolve the alert.
+Click "Edit this Page" in the top right corner to create a PR directly on GitHub.
+====

--- a/tests/golden/defaults/system-upgrade-controller/system-upgrade-controller/10_prometheusrule_system_upgrade_controller-alerts.yaml
+++ b/tests/golden/defaults/system-upgrade-controller/system-upgrade-controller/10_prometheusrule_system_upgrade_controller-alerts.yaml
@@ -14,14 +14,15 @@ spec:
       rules:
         - alert: SYN_SystemUpgradeControllerMaintenanceHalted
           annotations:
-            description: system-upgrade-controller has stopped because the node {{
+            description:
+              system-upgrade-controller has stopped because the node {{
               $labels.node }} cannot be drained. Check job logs for more information.
             message: Maintenance halted
-            runbook_url: https://hub.syn.tools/systen-upgrade-controller/runbooks/SystemUpgradeControllerMaintenanceHalted.html
+            runbook_url: https://hub.syn.tools/system-upgrade-controller/runbooks/SystemUpgradeControllerMaintenanceHalted.html
             severity_level: warning
           expr: kube_node_spec_unschedulable >= 1
           for: 15m
           labels:
             severity: warning
-            syn: 'true'
+            syn: "true"
             syn_component: system-upgrade-controller

--- a/tests/golden/defaults/system-upgrade-controller/system-upgrade-controller/10_prometheusrule_system_upgrade_controller-alerts.yaml
+++ b/tests/golden/defaults/system-upgrade-controller/system-upgrade-controller/10_prometheusrule_system_upgrade_controller-alerts.yaml
@@ -14,8 +14,7 @@ spec:
       rules:
         - alert: SYN_SystemUpgradeControllerMaintenanceHalted
           annotations:
-            description:
-              system-upgrade-controller has stopped because the node {{
+            description: system-upgrade-controller has stopped because the node {{
               $labels.node }} cannot be drained. Check job logs for more information.
             message: Maintenance halted
             runbook_url: https://hub.syn.tools/system-upgrade-controller/runbooks/SystemUpgradeControllerMaintenanceHalted.html
@@ -24,5 +23,5 @@ spec:
           for: 15m
           labels:
             severity: warning
-            syn: "true"
+            syn: 'true'
             syn_component: system-upgrade-controller

--- a/tests/golden/defaults/system-upgrade-controller/system-upgrade-controller/10_prometheusrule_system_upgrade_controller-alerts.yaml
+++ b/tests/golden/defaults/system-upgrade-controller/system-upgrade-controller/10_prometheusrule_system_upgrade_controller-alerts.yaml
@@ -1,0 +1,27 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: system-upgrade-controller-alert-rules
+    prometheus: platform
+    role: alert-rules
+  name: system-upgrade-controller-alert-rules
+  namespace: syn-synsights
+spec:
+  groups:
+    - name: system-upgrade-controller.rules
+      rules:
+        - alert: SYN_SystemUpgradeControllerMaintenanceHalted
+          annotations:
+            description: system-upgrade-controller has stopped because the node {{
+              $labels.node }} cannot be drained. Check job logs for more information.
+            message: Maintenance halted
+            runbook_url: https://hub.syn.tools/systen-upgrade-controller/runbooks/SystemUpgradeControllerMaintenanceHalted.html
+            severity_level: warning
+          expr: kube_node_spec_unschedulable >= 1
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: system-upgrade-controller


### PR DESCRIPTION
This PR adds a PrometheusRule that fires when a node cannot be drained and therefore the maintenance is halted.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
